### PR TITLE
code clean up and attempt to render animation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"image"
+	"image/gif"
 	_ "image/jpeg"
 	_ "image/png"
 	"io"
+	"mime"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lucasb-eyer/go-colorful"
@@ -51,6 +56,8 @@ type model struct {
 	image    string
 	height   uint
 	err      error
+
+	cancelAnimation context.CancelFunc
 }
 
 func (m model) Init() tea.Cmd {
@@ -91,25 +98,100 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.err = msg
 		return m, nil
 	case loadMsg:
-		url := m.urls[m.selected]
-		if msg.resp != nil {
-			defer msg.resp.Body.Close()
-			img, err := readerToImage(m.height, url, msg.resp.Body)
-			if err != nil {
-				return m, func() tea.Msg { return errMsg{err} }
-			}
-			m.image = img
-			return m, nil
-		}
-		defer msg.file.Close()
-		img, err := readerToImage(m.height, url, msg.file)
-		if err != nil {
-			return m, func() tea.Msg { return errMsg{err} }
-		}
-		m.image = img
-		return m, nil
+		return handleLoadMsg(m, msg)
+	case gifMsg:
+		return handleGifMsg(m, msg)
 	}
 	return m, nil
+}
+
+func handleGifMsg(m model, msg gifMsg) (model, tea.Cmd) {
+	m.image = msg.frames[msg.frame]
+	return m, func() tea.Msg {
+		nextFrame := msg.frame + 1
+		if nextFrame == len(msg.gif.Image) {
+			nextFrame = 0
+		}
+		select {
+		case <-msg.ctx.Done():
+			return nil
+		case <-time.After(time.Duration(msg.gif.Delay[nextFrame]*10) * time.Millisecond):
+			return gifMsg{
+				ctx:    msg.ctx,
+				gif:    msg.gif,
+				frames: msg.frames,
+				frame:  nextFrame,
+			}
+		}
+
+	}
+}
+
+func handleLoadMsg(m model, msg loadMsg) (model, tea.Cmd) {
+	if m.cancelAnimation != nil {
+		m.cancelAnimation()
+	}
+
+	// blank out image so it says "loading..."
+	m.image = ""
+
+	selected := m.urls[m.selected]
+	ext := filepath.Ext(selected)
+	t := mime.TypeByExtension(ext)
+	if strings.Contains(t, "gif") {
+		return handleLoadMsgAnimation(m, msg)
+	}
+	return handleLoadMsgStatic(m, msg)
+}
+
+func handleLoadMsgStatic(m model, msg loadMsg) (model, tea.Cmd) {
+	defer msg.Close()
+	r := msg.Reader()
+	url := m.urls[m.selected]
+	img, err := readerToImage(m.height, url, r)
+	if err != nil {
+		return m, func() tea.Msg { return errMsg{err} }
+	}
+	m.image = img
+	return m, nil
+}
+
+func handleLoadMsgAnimation(m model, msg loadMsg) (model, tea.Cmd) {
+	defer msg.Close()
+	r := msg.Reader()
+
+	// decode the gif
+	gimg, err := gif.DecodeAll(r)
+	if err != nil {
+		return m, wrapErrCmd(err)
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	m.cancelAnimation = cancel
+
+	// precompute the frames for performance reasons
+	var frames []string
+	for _, img := range gimg.Image {
+		str, err := imageToString(m.height, m.urls[m.selected], img)
+		if err != nil {
+			return m, wrapErrCmd(err)
+		}
+		frames = append(frames, str)
+	}
+
+	return m, func() tea.Msg {
+		return gifMsg{
+			gif:    gimg,
+			frames: frames,
+			frame:  0,
+			ctx:    ctx,
+		}
+	}
+}
+
+func wrapErrCmd(err error) tea.Cmd {
+	return func() tea.Msg { return errMsg{err} }
 }
 
 func (m model) View() string {
@@ -122,9 +204,27 @@ func (m model) View() string {
 	return m.image
 }
 
+type gifMsg struct {
+	gif    *gif.GIF
+	frame  int
+	frames []string
+	ctx    context.Context
+}
+
 type loadMsg struct {
 	resp *http.Response
 	file *os.File
+}
+
+func (l loadMsg) Reader() io.ReadCloser {
+	if l.resp != nil {
+		return l.resp.Body
+	}
+	return l.file
+}
+
+func (l loadMsg) Close() {
+	l.Reader().Close()
 }
 
 type errMsg struct{ error }
@@ -154,6 +254,10 @@ func readerToImage(height uint, url string, r io.Reader) (string, error) {
 		return "", err
 	}
 
+	return imageToString(height, url, img)
+}
+
+func imageToString(height uint, url string, img image.Image) (string, error) {
 	img = resize.Resize(0, height*2, img, resize.Lanczos3)
 	b := img.Bounds()
 	w := b.Max.X


### PR DESCRIPTION
![giphy](https://user-images.githubusercontent.com/177491/97112592-9c2fb600-16bb-11eb-947b-d2f6c84c2c2e.gif)

@muesli I made an attempt to do gif support. This branch represents that effort. The code "works" in the sense of if you hand it a gif it will animate it correctly. The problem I am hitting is either my terminal[1] or bubbletea doesn't seem fast enough to render the animation without lots of flashing/tearing.

Test gif I have been using attached to PR. Not sure if you have any clever ideas.

1. I use the terminal that comes with elementary os. I tried Hyper.sh too. It seems to perform a little better but I couldnt get trucolor's to kick in so it was mostly black an white.