### PR TITLE
Restructured the project so it can be used as a library in other progams as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 imgcat
+!cmd/imgcat
 dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - linux
       - windows
       - darwin
+    dir: ./cmd/imgcat
 archives:
   - replacements:
       darwin: Darwin

--- a/cmd/imgcat/main.go
+++ b/cmd/imgcat/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/trashhalo/imgcat"
+)
+
+const usage = `imgcat [pattern|url]
+
+Examples:
+    imgcat path/to/image.jpg
+    imgcat *.jpg
+    imgcat https://example.com/image.jpg`
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println(usage)
+		os.Exit(1)
+	}
+
+	if os.Args[1] == "-h" || os.Args[1] == "--help" {
+		fmt.Println(usage)
+		os.Exit(0)
+	}
+
+	p := tea.NewProgram(imgcat.NewModel(os.Args[1:len(os.Args)]))
+	p.EnterAltScreen()
+	defer p.ExitAltScreen()
+	if err := p.Start(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/console_windows.go
+++ b/console_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package main
+package imgcat
 
 import (
 	"os"


### PR DESCRIPTION
When I initially ran in this program I quickly got excited about what I could do with it inside some of my own internal tools. Only to realize everything was just in a single main.go file. So I figured I would split all of the logic into a separate file/library so it can easily be reused in other programs. The main binary as you're used to it is now in ./cmd/imgcat instead, this may require some adjusting to goreleaser.